### PR TITLE
Create a Type Alias for Floats

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,9 @@ use tableau::enter_vars::{enter_var_pivot_optimal, enter_var_pivot_feasible};
 use tableau::leave_vars::leave_var;
 use tableau::pivots::pivot_around;
 
-pub fn optimise(function: &mut Function, constraints: &SystemOfConstraints) -> Vec<(String, f32)> {
+type Num = f32;
+
+pub fn optimise(function: &mut Function, constraints: &SystemOfConstraints) -> Vec<(String, Num)> {
     rearrange_fun_eq_zero(function);
     transform_constraint_rels_to_eq(constraints);
     let mut table = get_initial_table_from(function, constraints);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use tableau::enter_vars::{enter_var_pivot_optimal, enter_var_pivot_feasible};
 use tableau::leave_vars::leave_var;
 use tableau::pivots::pivot_around;
 
-type Num = f32;
+pub type Num = f32;
 
 pub fn optimise(function: &mut Function, constraints: &SystemOfConstraints) -> Vec<(String, Num)> {
     rearrange_fun_eq_zero(function);

--- a/src/math/expressions.rs
+++ b/src/math/expressions.rs
@@ -1,5 +1,6 @@
 use std::mem;
 use std::result::Result;
+use Num;
 use math::variables::{AbstVar, new_const};
 use math::relationships::Relationship;
 
@@ -47,7 +48,7 @@ impl Expression {
         insert_side(&mut self.right_hand_side, to_move, insert_at_start);
     }
 
-    pub fn mul_both_sides(&mut self, by: f32) {
+    pub fn mul_both_sides(&mut self, by: Num) {
         mul_side(&mut self.left_hand_side, by);
         mul_side(&mut self.right_hand_side, by);
 
@@ -87,7 +88,7 @@ fn insert_side(side: &mut Vec<AbstVar>, var: AbstVar, start: bool) {
     }
 }
 
-fn mul_side(side: &mut Vec<AbstVar>, by: f32) {
+fn mul_side(side: &mut Vec<AbstVar>, by: Num) {
     for var in side.iter_mut() {
         match var {
             &mut AbstVar::Variable { ref mut coefficient, .. } => *coefficient = *coefficient * by,

--- a/src/math/variables.rs
+++ b/src/math/variables.rs
@@ -1,9 +1,10 @@
 use std::hash::{Hash, Hasher};
+use Num;
 
 #[derive(Debug, Clone)]
 pub enum AbstVar {
-    Variable { name: String, coefficient: f32 },
-    Constant { name: String, value: f32 },
+    Variable { name: String, coefficient: Num },
+    Constant { name: String, value: Num },
     SlackVar { name: String },
     SurplusVar { name: String },
 }
@@ -41,7 +42,7 @@ impl AbstVar {
         }
     }
 
-    pub fn get_data(&self) -> f32 {
+    pub fn get_data(&self) -> Num {
         match self {
             &AbstVar::Variable { ref coefficient, .. } => *coefficient,
             &AbstVar::Constant { ref value, .. } => *value,
@@ -50,7 +51,7 @@ impl AbstVar {
         }
     }
 
-    pub fn set_data(&mut self, d: f32) {
+    pub fn set_data(&mut self, d: Num) {
         match self {
             &mut AbstVar::Variable { ref mut coefficient, .. } => *coefficient = d,
             &mut AbstVar::Constant { ref mut value, .. } => *value = d,
@@ -67,14 +68,14 @@ impl AbstVar {
     }
 }
 
-pub fn new_var(n: &str, c: f32) -> AbstVar {
+pub fn new_var(n: &str, c: Num) -> AbstVar {
     AbstVar::Variable {
         name: n.to_string(),
         coefficient: c,
     }
 }
 
-pub fn new_const(n: &str, v: f32) -> AbstVar {
+pub fn new_const(n: &str, v: Num) -> AbstVar {
     AbstVar::Constant {
         name: n.to_string(),
         value: v,

--- a/src/tableau/initials.rs
+++ b/src/tableau/initials.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use Num;
 use objective::functions::Function;
 use objective::constraints::{Constraint, SystemOfConstraints};
 use tableau::tables::Table;
@@ -30,7 +31,7 @@ pub fn get_initial_table_from(fun: &Function, constraints: &SystemOfConstraints)
     // ... and don't forget about the constant on the right.
     let map_len = column_names.len();
     column_names.insert("RHS".to_string(), map_len);
-    let mut rows: Vec<Vec<f32>> = vec![vec![0.0; column_names.len()]; num_rows];
+    let mut rows: Vec<Vec<Num>> = vec![vec![0.0; column_names.len()]; num_rows];
     // Populate the table
     let mut row_index = 0;
     for constraint in constraints.system() {

--- a/src/tableau/tables.rs
+++ b/src/tableau/tables.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
 use std::result::Result;
+use Num;
 
 pub struct Table {
     column_names: HashMap<String, usize>, // assume last column reserved
-    rows: Vec<Vec<f32>>,
+    rows: Vec<Vec<Num>>,
 }
 
 impl Table {
-    pub fn new(c_n: HashMap<String, usize>, r: Vec<Vec<f32>>) -> Table {
+    pub fn new(c_n: HashMap<String, usize>, r: Vec<Vec<Num>>) -> Table {
         Table {
             rows: r,
             column_names: c_n,
@@ -18,14 +19,13 @@ impl Table {
         &self.column_names
     }
 
-    pub fn get_rows(&self) -> &Vec<Vec<f32>> {
+    pub fn get_rows(&self) -> &Vec<Vec<Num>> {
         &self.rows
     }
 
-    pub fn get_basic_solution(&self) -> Result<Vec<(String, f32)>, (usize, usize)> {
+    pub fn get_basic_solution(&self) -> Result<Vec<(String, Num)>, (usize, usize)> {
         let mut basic_solution = Vec::with_capacity(self.column_names.len());
         // Note: ignore RHS column.
-        println!("Bye");
         'columns: for i in 0..self.column_names.len() - 1 {
             let mut one_entry_index = 0;
             let mut matched_one = false;
@@ -51,7 +51,6 @@ impl Table {
             if matched_one {
                 let basic_variable_value = self.rows[one_entry_index][i] *
                                            self.rows[one_entry_index][self.column_names.len() - 1];
-                println!("{}, x = {},{},{}", basic_variable_value, self.rows[0][0], self.rows[1][0], self.rows[2][0]);
                 // If the basic variable turns out negative that this solution
                 // is not feasable...
                 if basic_variable_value.is_sign_negative() &&
@@ -80,11 +79,11 @@ impl Table {
         true
     }
 
-    pub fn sub_cell(&mut self, row_index: usize, colunm_index: usize, by: f32) {
+    pub fn sub_cell(&mut self, row_index: usize, colunm_index: usize, by: Num) {
         self.rows[row_index][colunm_index] = self.rows[row_index][colunm_index] - by;
     }
 
-    pub fn div_cell(&mut self, row_index: usize, colunm_index: usize, by: f32) {
+    pub fn div_cell(&mut self, row_index: usize, colunm_index: usize, by: Num) {
         self.rows[row_index][colunm_index] = self.rows[row_index][colunm_index] / by;
     }
 }


### PR DESCRIPTION
It would be nice to have single place to set the type of our float numbers. 

This is because currently the implementation does not work with `f64` and it would be nice to be able switch between `f32` and `f64` easily when we are debugging that. 

Also we can expose the alias to potential users so they don't need to worry about changing their code when the patch for using `f64` comes.