### PR TITLE
In some cases negative constants will not  be dealt with.

### DIFF
--- a/src/objective/solvers.rs
+++ b/src/objective/solvers.rs
@@ -1,7 +1,5 @@
-use std::ops::DerefMut;
 use math::variables::{new_slack_var, new_surplus_var};
 use math::relationships::Relationship;
-use math::expressions::Expression;
 use objective::functions::Function;
 use objective::constraints::{Constraint, SystemOfConstraints};
 
@@ -10,27 +8,25 @@ pub fn transform_constraint_rels_to_eq(constraints: &SystemOfConstraints) {
         match constraint {
             &Constraint::Regular(ref ref_cell) => {
                 let mut exp = ref_cell.borrow_mut();
-                if *exp.rel() == Relationship::LEQ {
-                    add_slack_var(exp.deref_mut(), i);
-                } else if *exp.rel() == Relationship::GEQ {
-                    if !exp.rhs()[0].get_data().is_sign_negative() {
+                if exp.rhs()[0].get_data().is_sign_negative() {
+                    // Negative constants on the right hand side are not allowed.
+                    exp.mul_both_sides(-1.0);
+                }
+                match exp.rel() {
+                    &Relationship::LEQ => {
+                        exp.add_lhs(new_slack_var(format!("{}{}", "sl", i + 1)));
+                        exp.set_rel(Relationship::EQ);
+                    }
+                    &Relationship::GEQ => {
                         exp.add_lhs(new_surplus_var(format!("{}{}", "su", i + 1)));
                         exp.set_rel(Relationship::EQ);
-                    } else {
-                        // Transform it first to a less than or equal to constraint.
-                        exp.mul_both_sides(-1.0);
-                        add_slack_var(exp.deref_mut(), i);
                     }
+                    _ => continue,
                 }
             }
             &Constraint::NonNegative(_) => continue,
         };
     }
-}
-
-fn add_slack_var(exp: &mut Expression, label_num: usize) {
-    exp.add_lhs(new_slack_var(format!("{}{}", "sl", label_num + 1)));
-    exp.set_rel(Relationship::EQ);
 }
 
 pub fn rearrange_fun_eq_zero(function: &mut Function) {


### PR DESCRIPTION
Simplex Method does not allow a problem to be formulated with negative constants on the right hand sides of constraints from the system of constraints.

- [ ] For any constraint with a negative constant multiply the `Expression` by `-1`.