### PR TITLE
Strict Variable Order

### DIFF
--- a/src/math/expressions.rs
+++ b/src/math/expressions.rs
@@ -37,11 +37,11 @@ impl Expression {
     }
 
     pub fn add_lhs(&mut self, to_add: AbstVar) {
-        add_side(&mut self.left_hand_side, to_add);
+        insert_side(&mut self.left_hand_side, to_add, false);
     }
 
     pub fn add_rhs(&mut self, to_add: AbstVar) {
-        add_side(&mut self.right_hand_side, to_add);
+        insert_side(&mut self.right_hand_side, to_add, false);
     }
 
     pub fn move_from_lhs_side(&mut self, index: usize, insert_at_start: bool) {
@@ -87,12 +87,6 @@ impl fmt::Debug for Expression {
     }
 }
 
-fn add_side(side: &mut Vec<AbstVar>, to_add: AbstVar) {
-    if let Some(new_var) = collect_into_existing(side, to_add) {
-        side.push(new_var);
-    }
-}
-
 fn collect_into_existing(side: &mut Vec<AbstVar>, to_add: AbstVar) -> Option<AbstVar> {
     for mut var in side.iter_mut() {
         if var == &to_add {
@@ -116,10 +110,13 @@ fn insert_side(side: &mut Vec<AbstVar>, var: AbstVar, start: bool) {
             while insert_at < side.len() {
                 match &side[insert_at] {
                     &AbstVar::Variable { .. } => insert_at += 1,
-                    _ => break,
+                    _ => {
+                        side.insert(insert_at, to_insert);
+                        return;
+                    }
                 };
             }
-            side.insert(insert_at, to_insert);
+            side.push(to_insert);
         }
     }
 }

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -108,9 +108,9 @@ mod tests {
         assert_eq!(3.0, exp1.lhs()[0].get_data());
         assert_eq!("w", exp1.lhs()[1].name());
         assert_eq!(9.0, exp1.lhs()[1].get_data());
-        assert_eq!("weight", exp1.lhs()[2].name());
-        assert_eq!(700.0, exp1.lhs()[2].get_data());
-        assert_eq!("s1", exp1.lhs()[3].name());
+        assert_eq!("s1", exp1.lhs()[2].name());
+        assert_eq!("weight", exp1.lhs()[3].name());
+        assert_eq!(700.0, exp1.lhs()[3].get_data());
         assert_eq!(Relationship::EQ, *exp1.rel());
         assert_eq!("x", exp1.rhs()[0].name());
         assert_eq!(2.0, exp1.rhs()[0].get_data());
@@ -134,13 +134,13 @@ mod tests {
         assert_eq!(2.0, exp2.rhs()[0].get_data());
         assert_eq!("y", exp2.rhs()[1].name());
         assert_eq!(3.0, exp2.rhs()[1].get_data());
-        assert_eq!("bonus", exp2.rhs()[2].name());
-        assert_eq!(1500.0, exp2.rhs()[2].get_data());
-        assert_eq!("w", exp2.rhs()[3].name());
-        assert_eq!(9.0, exp2.rhs()[3].get_data());
+        assert_eq!("w", exp2.rhs()[2].name());
+        assert_eq!(9.0, exp2.rhs()[2].get_data());
+        assert_eq!("s1", exp2.rhs()[3].name());
         assert_eq!("weight", exp2.rhs()[4].name());
         assert_eq!(700.0, exp2.rhs()[4].get_data());
-        assert_eq!("s1", exp2.rhs()[5].name());
+        assert_eq!("bonus", exp2.rhs()[5].name());
+        assert_eq!(1500.0, exp2.rhs()[5].get_data());
     }
 
     #[test]


### PR DESCRIPTION
At the moment there are known cases where the order of `Variable`(s) followed by non-`Variable`(s) is not  enforced.