### PR TITLE
Remove RefCell in Constraint Model

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,9 @@ use tableau::pivots::{pivot_around, apply_transition_rule};
 
 pub type Num = f32;
 
-pub fn optimise(function: &mut Function, constraints: &SystemOfConstraints) -> Vec<(String, Num)> {
+pub fn optimise(function: &mut Function,
+                constraints: &mut SystemOfConstraints)
+                -> Vec<(String, Num)> {
     rearrange_fun_eq_zero(function);
     if let Some(mut phase1_fun) = transform_constraint_rels_to_eq(constraints) {
         rearrange_fun_eq_zero(&mut phase1_fun);

--- a/src/objective/constraints.rs
+++ b/src/objective/constraints.rs
@@ -1,9 +1,8 @@
-use std::cell::RefCell;
 use math::variables::AbstVar;
 use math::expressions::Expression;
 
 pub enum Constraint {
-    Regular(RefCell<Expression>),
+    Regular(Expression),
     NonNegative(AbstVar),
 }
 
@@ -19,10 +18,14 @@ impl SystemOfConstraints {
     pub fn system(&self) -> &Vec<Constraint> {
         &self.constraints
     }
+
+    pub fn system_mut(&mut self) -> &mut Vec<Constraint> {
+        &mut self.constraints
+    }
 }
 
 pub fn new_reg_con(exp: Expression) -> Constraint {
-    Constraint::Regular(RefCell::new(exp))
+    Constraint::Regular(exp)
 }
 
 pub fn new_non_neg_con(var: AbstVar) -> Constraint {

--- a/src/objective/mod.rs
+++ b/src/objective/mod.rs
@@ -89,8 +89,7 @@ mod tests {
                                   vec![new_const("volume", 2300.0)]);
         let c1 = new_reg_con(exp);
         match c1 {
-            Constraint::Regular(ref_cell) => {
-                let exp = ref_cell.borrow();
+            Constraint::Regular(exp) => {
                 assert_eq!("x", exp.lhs()[0].name());
                 assert_eq!(2.0, exp.lhs()[0].get_data());
                 assert_eq!(Relationship::LEQ, *exp.rel());
@@ -122,8 +121,7 @@ mod tests {
         let s = SystemOfConstraints::new(vec![c1, c2]);
         for constraint in s.system() {
             match constraint {
-                &Constraint::Regular(ref ref_cell) => {
-                    let exp = ref_cell.borrow();
+                &Constraint::Regular(ref exp) => {
                     assert_eq!("x", exp.lhs()[0].name());
                     assert_eq!(2.0, exp.lhs()[0].get_data());
                     assert_eq!(Relationship::LEQ, *exp.rel());
@@ -159,8 +157,8 @@ mod tests {
         let c3 = new_reg_con(exp3);
         let c4 = new_reg_con(exp4);
         let c5 = new_non_neg_con(new_var("x", 2.0));
-        let s = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
-        let fun = transform_constraint_rels_to_eq(&s).unwrap();
+        let mut s = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
+        let fun = transform_constraint_rels_to_eq(&mut s).unwrap();
         assert_eq!("Expression { \
                    lhs: [Variable { name: \"W\", coefficient: 1 }], \
                    rel: EQ, \
@@ -169,8 +167,7 @@ mod tests {
                          Constant { name: \"RHS\", value: -500 }] }",
                    format!("{:?}", fun.exp_max().borrow()));
         match s.system()[0] {
-            Constraint::Regular(ref ref_cell) => {
-                let exp = ref_cell.borrow();
+            Constraint::Regular(ref exp) => {
                 assert_eq!("x", exp.lhs()[0].name());
                 assert_eq!(2.0, exp.lhs()[0].get_data());
                 assert_eq!(Relationship::EQ, *exp.rel());
@@ -183,8 +180,7 @@ mod tests {
             _ => panic!("Unexpected variant in this program logic."),
         };
         match s.system()[1] {
-            Constraint::Regular(ref ref_cell) => {
-                let exp = ref_cell.borrow();
+            Constraint::Regular(ref exp) => {
                 assert_eq!("w", exp.lhs()[0].name());
                 assert_eq!(6.0, exp.lhs()[0].get_data());
                 assert_eq!(Relationship::EQ, *exp.rel());
@@ -198,8 +194,7 @@ mod tests {
             _ => panic!("Unexpected variant in this program logic."),
         };
         match s.system()[2] {
-            Constraint::Regular(ref ref_cell) => {
-                let exp = ref_cell.borrow();
+            Constraint::Regular(ref exp) => {
                 assert_eq!("u", exp.lhs()[0].name());
                 assert_eq!(-61.0, exp.lhs()[0].get_data());
                 assert_eq!(Relationship::EQ, *exp.rel());
@@ -212,8 +207,7 @@ mod tests {
             _ => panic!("Unexpected variant in this program logic."),
         };
         match s.system()[3] {
-            Constraint::Regular(ref ref_cell) => {
-                let exp = ref_cell.borrow();
+            Constraint::Regular(ref exp) => {
                 assert_eq!("k", exp.lhs()[0].name());
                 assert_eq!(101.0, exp.lhs()[0].get_data());
                 assert_eq!(Relationship::EQ, *exp.rel());

--- a/src/objective/solvers.rs
+++ b/src/objective/solvers.rs
@@ -5,12 +5,11 @@ use objective::functions::Function;
 use objective::problems::ProblemType;
 use objective::constraints::{Constraint, SystemOfConstraints};
 
-pub fn transform_constraint_rels_to_eq(constraints: &SystemOfConstraints) -> Option<Function> {
+pub fn transform_constraint_rels_to_eq(constraints: &mut SystemOfConstraints) -> Option<Function> {
     let mut phase1: Option<Expression> = None;
-    for (i, constraint) in constraints.system().iter().enumerate() {
+    for (i, constraint) in constraints.system_mut().iter_mut().enumerate() {
         match constraint {
-            &Constraint::Regular(ref ref_cell) => {
-                let mut exp = ref_cell.borrow_mut();
+            &mut Constraint::Regular(ref mut exp) => {
                 if exp.rhs()[0].get_data().is_sign_negative() {
                     // Negative constants on the right hand side are not allowed.
                     exp.mul_both_sides(-1.0);
@@ -45,7 +44,7 @@ pub fn transform_constraint_rels_to_eq(constraints: &SystemOfConstraints) -> Opt
                     }
                 }
             }
-            &Constraint::NonNegative(_) => continue,
+            _ => continue,
         };
     }
     if let Some(phase1_fun_exp) = phase1 {

--- a/src/tableau/initials.rs
+++ b/src/tableau/initials.rs
@@ -13,9 +13,8 @@ pub fn get_initial_table_from(fun: &Function, constraints: &SystemOfConstraints)
     // with respect to a variable name.
     for constraint in constraints.system() {
         match constraint {
-            &Constraint::Regular(ref ref_cell) => {
+            &Constraint::Regular(ref exp) => {
                 num_rows += 1;
-                let exp = ref_cell.borrow();
                 for var in exp.lhs() {
                     insert_column_name_not_present(var.name().to_string(), &mut column_names);
                 }
@@ -35,8 +34,7 @@ pub fn get_initial_table_from(fun: &Function, constraints: &SystemOfConstraints)
     let mut row_index = 0;
     for constraint in constraints.system() {
         match constraint {
-            &Constraint::Regular(ref ref_cell) => {
-                let exp = ref_cell.borrow();
+            &Constraint::Regular(ref exp) => {
                 for var in exp.lhs() {
                     rows[row_index]
                         [*column_names.get(var.name())

--- a/src/tableau/mod.rs
+++ b/src/tableau/mod.rs
@@ -7,13 +7,12 @@ pub mod pivots;
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::cell::RefCell;
     use math::variables::{new_var, new_const};
     use math::relationships::Relationship;
     use math::expressions::Expression;
     use objective::problems::ProblemType;
     use objective::functions::Function;
-    use objective::constraints::{Constraint, SystemOfConstraints};
+    use objective::constraints::{SystemOfConstraints, new_reg_con, new_non_neg_con};
     use objective::solvers::{transform_constraint_rels_to_eq, rearrange_fun_eq_zero};
     use tableau::tables::Table;
     use tableau::initials::get_initial_table_from;
@@ -104,9 +103,7 @@ mod tests {
                                vec![0.0, 0.0, 0.0, 1.0 / 3.0, 1.0, -3.0, 5.0],
                                vec![0.0, 1.0, 0.0, -1.0 / 3.0, 0.0, 0.5, 10.0]];
         let table1 = Table::new(column_names1, table1_rows);
-        assert_eq!(vec![("x".to_string(), 10.0),
-                        ("y".to_string(), 10.0),
-                        ("t".to_string(), 5.0)],
+        assert_eq!(vec![("x".to_string(), 10.0), ("y".to_string(), 10.0), ("t".to_string(), 5.0)],
                    table1.get_basic_solution().unwrap());
 
         let mut column_names2: HashMap<String, usize> = HashMap::new();
@@ -187,13 +184,13 @@ mod tests {
         let e3 = Expression::new(vec![new_var("x1", 1.0), new_var("x2", 2.0), new_var("x3", 4.0)],
                                  Relationship::LEQ,
                                  vec![new_const("Woodworking (days)", 60.0)]);
-        let c1 = Constraint::Regular(RefCell::new(e2));
-        let c2 = Constraint::Regular(RefCell::new(e3));
-        let c3 = Constraint::NonNegative(new_var("x1", 1.0));
-        let c4 = Constraint::NonNegative(new_var("x2", 1.0));
-        let c5 = Constraint::NonNegative(new_var("x3", 1.0));
-        let system = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
-        transform_constraint_rels_to_eq(&system);
+        let c1 = new_reg_con(e2);
+        let c2 = new_reg_con(e3);
+        let c3 = new_non_neg_con(new_var("x1", 1.0));
+        let c4 = new_non_neg_con(new_var("x2", 1.0));
+        let c5 = new_non_neg_con(new_var("x3", 1.0));
+        let mut system = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
+        transform_constraint_rels_to_eq(&mut system);
         let table = get_initial_table_from(&f, &system);
         let table_header = table.get_column_names();
         let table_rows = table.get_rows();

--- a/src/tableau/pivots.rs
+++ b/src/tableau/pivots.rs
@@ -41,8 +41,7 @@ pub fn apply_transition_rule(a_v_i_s: Vec<(String, Num)>,
         let arti_var_row = table.get_row_of_basic_var(&basic_arti_var.0);
         for constraint in regular_constraints {
             match constraint {
-                &Constraint::Regular(ref ref_cell) => {
-                    let exp = ref_cell.borrow();
+                &Constraint::Regular(ref exp) => {
                     for var in exp.lhs() {
                         // Pivot on non artificial variable with coefficient not 0.
                         match var {

--- a/tests/simplex_test_max.rs
+++ b/tests/simplex_test_max.rs
@@ -27,8 +27,8 @@ fn simplex_test_max_1() {
     let c3 = new_reg_con(exp4);
     let c4 = new_non_neg_con(new_var("x", 1.0));
     let c5 = new_non_neg_con(new_var("y", 1.0));
-    let subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
-    let solution = cassowary::optimise(&mut objective_func, &subject_to);
+    let mut subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
+    let solution = cassowary::optimise(&mut objective_func, &mut subject_to);
     assert_eq!(4, solution.len());
     assert!(solution.contains(&("P".to_string(), 55.0)));
     assert!(solution.contains(&("x".to_string(), 10.0)));
@@ -53,8 +53,8 @@ fn simplex_test_max_2() {
     let c3 = new_non_neg_con(new_var("x1", 1.0));
     let c4 = new_non_neg_con(new_var("x2", 1.0));
     let c5 = new_non_neg_con(new_var("x3", 1.0));
-    let subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
-    let solution = cassowary::optimise(&mut objective_func, &subject_to);
+    let mut subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
+    let solution = cassowary::optimise(&mut objective_func, &mut subject_to);
     assert_eq!(3, solution.len());
     assert!(solution.contains(&("Z".to_string(), 64.0)));
     assert!(solution.contains(&("x1".to_string(), 8.0)));
@@ -78,8 +78,8 @@ fn simplex_test_max_3() {
     let c3 = new_non_neg_con(new_var("x1", 1.0));
     let c4 = new_non_neg_con(new_var("x2", 1.0));
     let c5 = new_non_neg_con(new_var("x3", 1.0));
-    let subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
-    let solution = cassowary::optimise(&mut objective_func, &subject_to);
+    let mut subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
+    let solution = cassowary::optimise(&mut objective_func, &mut subject_to);
     assert_eq!(3, solution.len());
     assert!(solution.contains(&("P".to_string(), 4400.0)));
     assert!(solution.contains(&("x1".to_string(), 200.0)));
@@ -111,8 +111,8 @@ fn simplex_test_max_4() {
     let c5 = new_non_neg_con(new_var("x2", 1.0));
     let c6 = new_non_neg_con(new_var("x3", 1.0));
     let c7 = new_non_neg_con(new_var("x4", 1.0));
-    let subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5, c6, c7]);
-    let solution = cassowary::optimise(&mut objective_func, &subject_to);
+    let mut subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5, c6, c7]);
+    let solution = cassowary::optimise(&mut objective_func, &mut subject_to);
     assert_eq!(4, solution.len());
     assert!(solution.contains(&("Z".to_string(), 1.5)));
     assert!(solution.contains(&("x2".to_string(), 2.5)));
@@ -141,8 +141,8 @@ fn simplex_test_max_5() {
     let c4 = new_non_neg_con(new_var("x1", 1.0));
     let c5 = new_non_neg_con(new_var("x2", 1.0));
     let c6 = new_non_neg_con(new_var("x3", 1.0));
-    let subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5, c6]);
-    let solution = cassowary::optimise(&mut objective_func, &subject_to);
+    let mut subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5, c6]);
+    let solution = cassowary::optimise(&mut objective_func, &mut subject_to);
     assert!(solution.contains(&("P".to_string(), 10.0)));
     assert!(solution.contains(&("x2".to_string(), 5.0)));
     assert!(solution.contains(&("x3".to_string(), 5.0)));
@@ -170,8 +170,8 @@ fn simplex_test_max_6() {
     let c4 = new_non_neg_con(new_var("x1", 1.0));
     let c5 = new_non_neg_con(new_var("x2", 1.0));
     let c6 = new_non_neg_con(new_var("x3", 1.0));
-    let subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5, c6]);
-    let solution = cassowary::optimise(&mut objective_func, &subject_to);
+    let mut subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5, c6]);
+    let solution = cassowary::optimise(&mut objective_func, &mut subject_to);
     assert!(solution.contains(&("F".to_string(), 660.0)));
     assert!(solution.contains(&("x2".to_string(), 60.000004)));
     assert!(solution.contains(&("x3".to_string(), 120.0)));

--- a/tests/simplex_test_min.rs
+++ b/tests/simplex_test_min.rs
@@ -76,9 +76,9 @@ fn simplex_test_min_1() {
     let c10 = new_non_neg_con(new_var("p", 1.0));
     let c11 = new_non_neg_con(new_var("f", 1.0));
     let c12 = new_non_neg_con(new_var("y", 1.0));
-    let subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11,
-                                                   c12]);
-    let solution = cassowary::optimise(&mut objective_func, &subject_to);
+    let mut subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5, c6, c7, c8, c9, c10,
+                                                       c11, c12]);
+    let solution = cassowary::optimise(&mut objective_func, &mut subject_to);
     assert_eq!(7, solution.len());
     assert!(solution.contains(&("C".to_string(), 9.174414)));
     assert!(solution.contains(&("m".to_string(), 0.5644002)));
@@ -106,8 +106,8 @@ fn simplex_test_min_2() {
     let c3 = new_non_neg_con(new_var("x", 1.0));
     let c4 = new_non_neg_con(new_var("y", 1.0));
     let c5 = new_non_neg_con(new_var("z", 1.0));
-    let subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
-    let solution = cassowary::optimise(&mut objective_func, &subject_to);
+    let mut subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
+    let solution = cassowary::optimise(&mut objective_func, &mut subject_to);
     assert_eq!(3, solution.len());
     assert!(solution.contains(&("P".to_string(), -38.0 / 3.0)));
     assert!(solution.contains(&("y".to_string(), 7.0 / 3.0)));
@@ -131,8 +131,8 @@ fn simplex_test_min_3() {
     let c3 = new_non_neg_con(new_var("y1", 1.0));
     let c4 = new_non_neg_con(new_var("y2", 1.0));
     let c5 = new_non_neg_con(new_var("y3", 1.0));
-    let subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
-    let solution = cassowary::optimise(&mut objective_func, &subject_to);
+    let mut subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
+    let solution = cassowary::optimise(&mut objective_func, &mut subject_to);
     assert_eq!(3, solution.len());
     assert!(solution.contains(&("W".to_string(), 20.0)));
     assert!(solution.contains(&("y2".to_string(), 10.0)));
@@ -155,8 +155,8 @@ fn simplex_test_min_4() {
     let c2 = new_reg_con(exp3);
     let c3 = new_non_neg_con(new_var("x1", 1.0));
     let c4 = new_non_neg_con(new_var("x2", 1.0));
-    let subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4]);
-    let solution = cassowary::optimise(&mut objective_func, &subject_to);
+    let mut subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4]);
+    let solution = cassowary::optimise(&mut objective_func, &mut subject_to);
     assert_eq!(3, solution.len());
     assert!(solution.contains(&("C".to_string(), 24.0)));
     assert!(solution.contains(&("x1".to_string(), 8.0)));
@@ -190,8 +190,8 @@ fn simplex_test_min_5() {
     let c3 = new_reg_con(exp4);
     let c4 = new_non_neg_con(new_var("x1", 1.0));
     let c5 = new_non_neg_con(new_var("x2", 1.0));
-    let subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
-    let solution = cassowary::optimise(&mut objective_func, &subject_to);
+    let mut subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
+    let solution = cassowary::optimise(&mut objective_func, &mut subject_to);
     assert_eq!(4, solution.len());
     assert!(solution.contains(&("Z".to_string(), 25.0)));
     assert!(solution.contains(&("x1".to_string(), 5.0)));
@@ -219,8 +219,8 @@ fn simplex_test_min_6() {
     let c3 = new_reg_con(exp4);
     let c4 = new_non_neg_con(new_var("x1", 1.0));
     let c5 = new_non_neg_con(new_var("x2", 1.0));
-    let subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
-    let solution = cassowary::optimise(&mut objective_func, &subject_to);
+    let mut subject_to = SystemOfConstraints::new(vec![c1, c2, c3, c4, c5]);
+    let solution = cassowary::optimise(&mut objective_func, &mut subject_to);
     assert_eq!(4, solution.len());
     assert!(solution.contains(&("Z".to_string(), 23.0 / 7.0)));
     assert!(solution.contains(&("x1".to_string(), 5.0 / 7.0)));


### PR DESCRIPTION
Removing `RefCell` will not give us significant (or any tbh) speed gain for the linear problems we input at the moment however I can't find a justification for keeping it either. I am not even sure how this construct will ever be helpful and it certainly makes my code at the moment more complicated than it needs to be.

I started using it because I got confused on how to write my code so that the `rustc` stops moaning about borrowing `immutable` content as `mutable`. I fell into this trap trying to update an old value of a field by setting a new value and the problem actually was that I was not allowed to read and set in the same `Rust` statement.