### PR TITLE
Derive Clone on Constraint Model.

### DIFF
--- a/src/math/expressions.rs
+++ b/src/math/expressions.rs
@@ -5,6 +5,7 @@ use Num;
 use math::variables::{AbstVar, new_const};
 use math::relationships::Relationship;
 
+#[derive(Clone)]
 pub struct Expression {
     left_hand_side: Vec<AbstVar>,
     relationship: Relationship,

--- a/src/math/relationships.rs
+++ b/src/math/relationships.rs
@@ -1,4 +1,4 @@
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum Relationship {
     EQ,
     LEQ,

--- a/src/objective/constraints.rs
+++ b/src/objective/constraints.rs
@@ -1,6 +1,7 @@
 use math::variables::AbstVar;
 use math::expressions::Expression;
 
+#[derive(Clone)]
 pub enum Constraint {
     Regular(Expression),
     NonNegative(AbstVar),


### PR DESCRIPTION
- [x] Add the ability for Constraints to be copied.

This will unlock Rust's `extend_from_slice` `Vec` method. 